### PR TITLE
command_casing: Remove case sensitivity from bot commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,7 @@ from bot.command import DiscordCommand
 
 import web
 
-bot = commands.Bot(command_prefix='!')
+bot = commands.Bot(command_prefix='!', case_insensitive=True)
 
 ROOT = os.path.dirname(__file__)
 


### PR DESCRIPTION
New special play commands are case sensitive, changing the bot to accept any casing.